### PR TITLE
fixed some ampersands

### DIFF
--- a/mbx/sec_dot_product.mbx
+++ b/mbx/sec_dot_product.mbx
@@ -352,7 +352,7 @@ Let <m>\vec u</m> and <m>\vec v</m> be given. The <term>orthogonal projection of
 </statement>
 <solution>
 <ol>
-<li><line>Applying <xref ref="def_orthogonal_projection">Definition</xref>, we have
+<li>Applying <xref ref="def_orthogonal_projection">Definition</xref>, we have
 <md>
   <mrow>  \proj uv \amp = \frac{\dotp uv}{\dotp vv}\vec v</mrow>
   <mrow>  \amp = \frac{-5}{10}\la 3,1\ra</mrow>
@@ -362,8 +362,8 @@ Vectors <m>\vec u</m>, <m>\vec v</m> and <m>\proj uv</m> are sketched in <xref r
 \begin{figure}
 \begin{tabular}c
 <image width="73%" source="images/figdotp4a.png" />
-(a)</line>
-<line>\begin{figure}
+(a)
+\begin{figure}
 \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
 3Droll=0,
 3Dortho=0.0046,
@@ -372,8 +372,8 @@ Vectors <m>\vec u</m>, <m>\vec v</m> and <m>\proj uv</m> are sketched in <xref r
 3Droo=250,
 3Dlights=Headlamp,add3Djscript=asylabels.js]
 <image width="73%" source="images/figdotp4b.png" />
-(b)</line>
-<line><figure xml:id="fig_dotp4" >
+(b)
+<figure xml:id="fig_dotp4" >
 <caption>Graphing the vectors used in <xref ref="ex_dotp4">Example</xref>.</caption>
 \includemedia[width=100pt,3Dmenu,activate=onclick,deactivate=onclick,
 3Droll=0,
@@ -383,10 +383,9 @@ Vectors <m>\vec u</m>, <m>\vec v</m> and <m>\proj uv</m> are sketched in <xref r
 3Droo=250,
 3Dlights=Headlamp,add3Djscript=asylabels.js]
 <image width="73%" source="images/figdotp4c.png" />
-(c)</line>
-<line>\end{tabular}
+(c)
+\end{tabular}
 </figure>
-</line>
 </li>
 <li>Apply the definition:
 <md>

--- a/mbx/sec_hyperbolic.mbx
+++ b/mbx/sec_hyperbolic.mbx
@@ -93,9 +93,9 @@ Use <xref ref="def_hyperbolic_functions">Definition</xref> to rewrite the follow
 </statement>
 <solution>
 <ol>
-<li><line>\cosh^2x-\sinh^2x &= \left(\frac{e^x+e^{-x}}2\right)^2 -\left(\frac{e^x-e^{-x}}2\right)^2</line>
-<line>&= \frac{e^{2x}+2e^xe^{-x} + e^{-2x}}4 - \frac{e^{2x}-2e^xe^{-x} + e^{-2x}}4</line>
-<line>&= \frac44=1.
+<li><line>\cosh^2x-\sinh^2x <amp />= \left(\frac{e^x+e^{-x}}2\right)^2 -\left(\frac{e^x-e^{-x}}2\right)^2</line>
+<line><amp />= \frac{e^{2x}+2e^xe^{-x} + e^{-2x}}4 - \frac{e^{2x}-2e^xe^{-x} + e^{-2x}}4</line>
+<line><amp />= \frac44=1.
 \end{aligned}$
 
 So $\cosh^2 x-\sinh^2x=1$.</line>

--- a/mbx/sec_polar.mbx
+++ b/mbx/sec_polar.mbx
@@ -424,9 +424,9 @@ There are a number of basic and <q>classic</q> polar curves, famous for their be
 </p>
 <tabular>
 {p{\gallerywidth}p{\gallerywidth}p{\gallerywidth}p{\gallerywidth}}
-<b>Centered on <m>x</m>-axis:</b> <amp /> <b>Centered on <m>y</m>-axis:</b> <amp /> <b>Centered on origin:</b> &<b>Archimedean spiral</b>\\
+<b>Centered on <m>x</m>-axis:</b> <amp /> <b>Centered on <m>y</m>-axis:</b> <amp /> <b>Centered on origin:</b> <amp /><b>Archimedean spiral</b>\\
 <m>r=a\cos \theta</m> <amp /> <m>r=a\sin\theta</m> <amp /> <m>r=a</m> <amp /> <m>r=\theta</m>\\
-<image width="90%" source="images/figpolarcircle1.png" /> &<image width="90%" source="images/figpolarcircle2.png" /> &<image width="90%" source="images/figpolarcircle3.png" /> &<image width="90%" source="images/figpolarspiral.png" />
+<image width="90%" source="images/figpolarcircle1.png" /> <amp /><image width="90%" source="images/figpolarcircle2.png" /> <amp /><image width="90%" source="images/figpolarcircle3.png" /> <amp /><image width="90%" source="images/figpolarspiral.png" />
 </tabular>
 </subsection>
 

--- a/mbx/sec_taylor_series.mbx
+++ b/mbx/sec_taylor_series.mbx
@@ -303,7 +303,7 @@ Unfortunately, this particular expansion of <m>\pi</m> converges very slowly. Th
 </p>
 
 <p>
-<m>\ds \frac{1}{1-x} = \sum_{n=0}^\infty x^n</m> &<m>\ds 1+x+x^2+x^3+\cdots</m><amp /> <m>(-1,1)</m>
+<m>\ds \frac{1}{1-x} = \sum_{n=0}^\infty x^n</m> <amp /><m>\ds 1+x+x^2+x^3+\cdots</m><amp /> <m>(-1,1)</m>
 </p>
 
 <p>


### PR DESCRIPTION
Some ampersands fixed.

If more of these remain, then I have to make my pattern match more clever.

The specific example in sec_hyperbolic.mbx arises from some LaTeX source
that is constructed oddly, and which will have to be fixed by hand.

I probably fixed the illegal xml in     mbx/sec_dot_product.mbx, but what remains is
probably nonsense.
